### PR TITLE
added sso.require_activation option to config file

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -26,6 +26,8 @@ class LoginController < ApplicationController
     sso.sso_secret = configatron.sso.secret
     sso.sso_url = sso.return_sso_url
 
+    sso.require_activation = configatron.sso.require_activation
+
     if configatron.custom_field.username
       sso.custom_fields["orig_username"] = username
     end

--- a/config/configatron/defaults.rb
+++ b/config/configatron/defaults.rb
@@ -10,6 +10,8 @@
 
 configatron.sso.login.path = '/session/sso_login'
 configatron.sso.secret = 'ToTX`#TLy@ioR^exPKb@&sfyD'
+configatron.sso.require_activation = false            # must set to true if not all CAS email addresses are trusted / validated by your CAS server
+                                                      # https://meta.discourse.org/t/official-single-sign-on-for-discourse-sso/13045
 
 configatron.sso.suppress_welcome_message = false
 

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,8 +1,8 @@
 class SingleSignOn
   ACCESSORS = [:nonce, :name, :username, :email, :avatar_url, :avatar_force_update,
-               :about_me, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message]
+               :about_me, :external_id, :return_sso_url, :admin, :moderator, :suppress_welcome_message, :require_activation]
   FIXNUMS = []
-  BOOLS = [:avatar_force_update, :admin, :moderator, :suppress_welcome_message]
+  BOOLS = [:avatar_force_update, :admin, :moderator, :suppress_welcome_message, :require_activation]
   NONCE_EXPIRY_TIME = 10.minutes
 
   attr_accessor(*ACCESSORS)


### PR DESCRIPTION
this option is needed if your CAS server doesn't validate all email
addresses, to avoid account hijacking when there are matching email
addresses for new and existing users.